### PR TITLE
Enable build of loaders variant for PHP 8.0 for Source Guardian support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         php_version: ["7.2", "7.3", "7.4", "8.0"]
-        include:
-          # IonCube and Source Guardian loaders do not yet exist for PHP 8.0
-          - php_version: "8.0"
-            php_variants: "cli fpm"
     steps:
     - uses: actions/checkout@v1
     - run: ./scripts/build.sh --push

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Images are built and tagged using both stable and version specific tags to support pinning downstream builds to latest available for `7.4` or to a specific version such as `7.4.16`. Please reference the [image repository](https://hub.docker.com/r/davidalger/php) on Docker Hub for a complete list of available tags. Builds are automatically run on the 1st of each month and/or when changes are pushed to the master branch of this repository.
 
-* `8.0`, `8.0-fpm`
+* `8.0`, `8.0-loaders`, `8.0-fpm`, `8.0-fpm-loaders`
 * `7.4`, `7.4-loaders`, `7.4-fpm`, `7.4-fpm-loaders`
 * `7.3`, `7.3-loaders`, `7.3-fpm`, `7.3-fpm-loaders`
 * `7.2`, `7.2-loaders`, `7.2-fpm`, `7.2-fpm-loaders`

--- a/cli-loaders/Dockerfile
+++ b/cli-loaders/Dockerfile
@@ -18,6 +18,12 @@ RUN PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | cut -d. -f1-2) \
     && cd /tmp/ioncube \
     && curl -Os https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
     && tar xzf ioncube_loaders_lin_x86-64.tar.gz \
-    && cp ioncube/ioncube_loader_lin_${PHP_VERSION}.so "$(php -i | grep '^extension_dir =' | cut -d' ' -f3)/ioncube_loader.so" \
-    && echo "zend_extension=ioncube_loader.so" > /etc/php.d/01-ioncube-loader.ini \
+    && IONCUBE_LOADER_PATH=ioncube/ioncube_loader_lin_${PHP_VERSION}.so \
+    && if [[ -f ${IONCUBE_LOADER_PATH} ]]; then \
+        cp ${IONCUBE_LOADER_PATH} "$(php -i | grep '^extension_dir =' | cut -d' ' -f3)/ioncube_loader.so" \
+            && echo "zend_extension=ioncube_loader.so" > /etc/php.d/01-ioncube-loader.ini; \
+    else \
+        >&2 printf "\033[33mWARNING\033[0m: IonCube loaders for PHP_VERSION %s could not be found at %s\n" \
+            "${PHP_VERSION}" "${IONCUBE_LOADER_PATH}"; \
+    fi \
     && rm -rf /tmp/ioncube

--- a/fpm-loaders/Dockerfile
+++ b/fpm-loaders/Dockerfile
@@ -18,6 +18,12 @@ RUN PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | cut -d. -f1-2) \
     && cd /tmp/ioncube \
     && curl -Os https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
     && tar xzf ioncube_loaders_lin_x86-64.tar.gz \
-    && cp ioncube/ioncube_loader_lin_${PHP_VERSION}.so "$(php -i | grep '^extension_dir =' | cut -d' ' -f3)/ioncube_loader.so" \
-    && echo "zend_extension=ioncube_loader.so" > /etc/php.d/01-ioncube-loader.ini \
+    && IONCUBE_LOADER_PATH=ioncube/ioncube_loader_lin_${PHP_VERSION}.so \
+    && if [[ -f ${IONCUBE_LOADER_PATH} ]]; then \
+        cp ${IONCUBE_LOADER_PATH} "$(php -i | grep '^extension_dir =' | cut -d' ' -f3)/ioncube_loader.so" \
+            && echo "zend_extension=ioncube_loader.so" > /etc/php.d/01-ioncube-loader.ini; \
+    else \
+        >&2 printf "\033[33mWARNING\033[0m: IonCube loaders for PHP_VERSION %s could not be found at %s\n" \
+            "${PHP_VERSION}" "${IONCUBE_LOADER_PATH}"; \
+    fi \
     && rm -rf /tmp/ioncube


### PR DESCRIPTION
Source Guardian loaders for PHP 8.0 are available, so this PR accomplishes two things:

* Updates CI to build the `8.0-loaders` and `8.0-fpm-loaders` image variants.
* Updates image builds to emit a warning and exit successfully when IonCube loaders are not found for the PHP_VERSION being built (they _still_ do not have a loader available for PHP 8.0)
