### PR TITLE
Fixed build main php image

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y \
 RUN set -eux \
     && dnf install -y epel-release \
     && dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm \
-    && dnf module reset php \
+    && dnf module reset php -y \
     && dnf module install -y php:remi-${PHP_VERSION} \
     && PHP_VERSION=$(echo ${PHP_VERSION} | awk -F '.' '{print $1$2}') \
     && PHP_PACKAGES= && for PKG in ${PHP_EXTENSIONS}; do \


### PR DESCRIPTION
At last pipeline I faced with problem of import gpg segnature. This PR fixed issue by adding agree flag.

Error:
```
+ dnf module reset php
Remi's Modular repository for Enterprise Linux  1.4 kB/s | 858  B     00:00    
Remi's Modular repository for Enterprise Linux  3.0 MB/s | 3.1 kB     00:00    
Importing GPG key 0x5F11735A:
 Userid     : "Remi's RPM repository <remi@remirepo.net>"
 Fingerprint: 6B38 FEA7 231F 87F5 2B9C A9D8 5550 9759 5F11 735A
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-remi.el8
Is this ok [y/N]: Remi's Modular repository for Enterprise Linux  2.4 kB/s | 858  B     00:00    
Error: Failed to download metadata for repo 'remi-modular': repomd.xml GPG signature verification error: Bad GPG signature
```